### PR TITLE
oEmbed 1.0 cleanup

### DIFF
--- a/jquery.oembed.js
+++ b/jquery.oembed.js
@@ -157,7 +157,8 @@
     new OEmbedProvider("wordpress", "wordpress.com"),
     new OEmbedProvider("youtube", "youtube.com"),
     new OEmbedProvider("vids.myspace.com", "vids.myspace.com", "http://vids.myspace.com/index.cfm?fuseaction=oembed"),
-    new OEmbedProvider("screenr", "screenr.com", "http://screenr.com/api/oembed.json")
+    new OEmbedProvider("screenr", "screenr.com", "http://screenr.com/api/oembed.json"),
+    new OEmbedProvider("soundcloud", "soundcloud.com", "http://soundcloud.com/oembed", false, 'js')
   ];
 
   function OEmbedProvider(name, urlPattern, oEmbedUrl, callbackparameter, format) {

--- a/jquery.oembed.js
+++ b/jquery.oembed.js
@@ -1,223 +1,238 @@
-﻿(function($) {
-    $.fn.oembed = function(url, options, callback) {
+/* Forked from http://code.google.com/p/jquery-oembed/
+ * Likely created by Richard Chamorro under the MIT license.
+ * Tweaked up by Samuel Cole.
+ */
+(function($) {
+  $.fn.oembed = function(url, options, callback) {
+    options = $.extend(true, $.fn.oembed.defaults, options);
 
-        options = $.extend(true, $.fn.oembed.defaults, options);
+    return this.each(function() {
 
-        return this.each(function() {
+      var container = $(this),
+           resourceURL = (url !== null) ? url : container.attr("href"),
+           provider;
 
-            var container = $(this),
-				resourceURL = (url != null) ? url : container.attr("href"),
-				provider;
+      if (!callback) callback = function(container, oembed) {
+        $.fn.oembed.insertCode(container, options.embedMethod, oembed);
+      };
 
-            if (!callback) callback = function(container, oembed) {			
-				 $.fn.oembed.insertCode(container, options.embedMethod, oembed);
-            };
+      if (resourceURL !== null) {
+        provider = getOEmbedProvider(resourceURL);
 
-            if (resourceURL != null) {
-                provider = getOEmbedProvider(resourceURL);
-
-                if (provider != null) {						
-					provider.params = getNormalizedParams(options[provider.name]) || {};
-                    provider.maxWidth = options.maxWidth;
-                    provider.maxHeight = options.maxHeight;										
-                    provider.embedCode(container, resourceURL, callback);
-                    return;
-                }
-            }
-
-            callback(container, null);
-        });
-    };
-
-    // Plugin defaults
-    $.fn.oembed.defaults = {
-        maxWidth: null,
-        maxHeight: null,
-		embedMethod: "replace" // "auto", "append", "fill"
-    };
-	
-	$.fn.oembed.insertCode = function(container, embedMethod, oembed) {
-		if (oembed == null)
-			return;
-		switch(embedMethod)
-		{
-			case "auto":				
-                if (container.attr("href") != null) {
-					$.fn.oembed.insertCode(container, "append", oembed);
-				}
-				else {
-					$.fn.oembed.insertCode(container, "replace", oembed);
-				};
-				break;
-			case "replace":	
-				container.replaceWith(oembed.code);
-				break;
-			case "fill":
-				container.html(oembed.code);
-				break;
-			case "append":
-                var oembedContainer = container.next();
-				if (oembedContainer == null || !oembedContainer.hasClass("oembed-container")) {
-					oembedContainer = container
-						.after('<div class="oembed-container"></div>')
-						.next(".oembed-container");
-					if (oembed != null && oembed.provider_name != null)
-					    oembedContainer.toggleClass("oembed-container-" + oembed.provider_name);		
-				}
-				oembedContainer.html(oembed.code);				
-				break;			
-		}
-	};
-
-    $.fn.oembed.getPhotoCode = function(url, data) {
-	    var alt = data.title ? data.title : '';
-        alt += data.author_name ? ' - ' + data.author_name : '';
-        alt += data.provider_name ? ' - ' +data.provider_name : '';
-        var code = '<div><a href="' + url + '" target="_blank"><img src="' + data.url + '" alt="' + alt + '"/></a></div>';
-        if (data.html)
-            code += "<div>" + data.html + "</div>";
-        return code;
-    };
-
-    $.fn.oembed.getVideoCode = function(url, data) {
-        var code = data.html;
-        return code;
-    };
-
-    $.fn.oembed.getRichCode = function(url, data) {
-        var code = data.html;
-        return code;
-    };
-
-    $.fn.oembed.getGenericCode = function(url, data) {
-        var title = (data.title != null) ? data.title : url,
-			code = '<a href="' + url + '">' + title + '</a>';
-        if (data.html)
-            code += "<div>" + data.html + "</div>";
-        return code;
-    };
-
-    $.fn.oembed.isAvailable = function(url) {
-        var provider = getOEmbedProvider(url);
-        return (provider != null);
-    };
-
-    /* Private Methods */
-    function getOEmbedProvider(url) {
-        for (var i = 0; i < providers.length; i++) {
-            if (providers[i].matches(url))
-                return providers[i];
-        }
-        return null;
-    }
-	
-	function getNormalizedParams(params) {
-		if (params == null)
-			return null;
-		var normalizedParams = {};
-		for (var key in params) {
-			if (key != null)
-				normalizedParams[key.toLowerCase()] = params[key];
-		}
-		return normalizedParams;
-	}
-
-    var providers = [
-        new OEmbedProvider("fivemin", "5min.com"),
-        new OEmbedProvider("amazon", "amazon.com"),
-        new OEmbedProvider("flickr", "flickr", "http://flickr.com/services/oembed", "jsoncallback"),    
-        new OEmbedProvider("googlevideo", "video.google."),
-        new OEmbedProvider("hulu", "hulu.com"),
-        new OEmbedProvider("imdb", "imdb.com"),
-        new OEmbedProvider("metacafe", "metacafe.com"),
-        new OEmbedProvider("qik", "qik.com"),
-        new OEmbedProvider("revision3", "revision3.com"),
-        new OEmbedProvider("slideshare", "slideshare.net"),
-        new OEmbedProvider("twitpic", "twitpic.com"),
-        new OEmbedProvider("viddler", "viddler.com"),
-        new OEmbedProvider("vimeo", "vimeo.com", "http://vimeo.com/api/oembed.json"),
-        new OEmbedProvider("wikipedia", "wikipedia.org"),
-        new OEmbedProvider("wordpress", "wordpress.com"),
-        new OEmbedProvider("youtube", "youtube.com"),
-        new OEmbedProvider("vids.myspace.com", "vids.myspace.com", "http://vids.myspace.com/index.cfm?fuseaction=oembed"),
-		new OEmbedProvider("screenr", "screenr.com", "http://screenr.com/api/oembed.json")
-    ];
-
-    function OEmbedProvider(name, urlPattern, oEmbedUrl, callbackparameter) {
-        this.name = name;
-        this.urlPattern = urlPattern;
-        this.oEmbedUrl = (oEmbedUrl != null) ? oEmbedUrl : "http://oohembed.com/oohembed/";
-        this.callbackparameter = (callbackparameter != null) ? callbackparameter : "callback";
-        this.maxWidth = 500;
-        this.maxHeight = 400;
-
-        this.matches = function(externalUrl) {
-            // TODO: Convert to Regex
-            return externalUrl.indexOf(this.urlPattern) >= 0;
-        };
-
-        this.getRequestUrl = function(externalUrl) {
-
-            var url = this.oEmbedUrl;
-
-            if (url.indexOf("?") <= 0)
-                url = url + "?";
-			else
-				url = url + "&";
-
-			var qs = "";
-			
-			if (this.maxWidth != null && this.params["maxwidth"] == null)
-				this.params["maxwidth"] = this.maxWidth;				
-				
-			if (this.maxHeight != null && this.params["maxheight"] == null)
-				this.params["maxheight"] = this.maxHeight;
-
-			for (var i in this.params) {
-                // We don't want them to jack everything up by changing the callback parameter
-                if (i == this.callbackparameter)
-                  continue;
-                
-				// allows the options to be set to null, don't send null values to the server as parameters
-                if (this.params[i] != null)
-                	qs += "&" + escape(i) + "=" + this.params[i];
-            }			
-            
-				
-			url += "format=json&url=" + escape(externalUrl) + 			
-					qs + 
-					"&" + this.callbackparameter + "=?";
-					
-            return url;
-        };
-
-        this.embedCode = function(container, externalUrl, callback) {
-
-            var request = this.getRequestUrl(externalUrl);
-
-            $.getJSON(request, function(data) {
-
-                var oembed = $.extend(data);
-
-                var code, type = data.type;
-
-                switch (type) {
-                    case "photo":
-                        oembed.code = $.fn.oembed.getPhotoCode(externalUrl, data);
-                        break;
-                    case "video":
-                        oembed.code = $.fn.oembed.getVideoCode(externalUrl, data);
-                        break;
-                    case "rich":
-                        oembed.code = $.fn.oembed.getRichCode(externalUrl, data);
-                        break;
-                    default:
-                        oembed.code = $.fn.oembed.getGenericCode(externalUrl, data);
-                        break;
-                }
-
-                callback(container, oembed);
+        if (provider !== null) {
+          if(options.allowed_providers.length) {
+            var allowed = false;
+            $.each(options.allowed_providers, function() {
+              if(provider.name == this) {
+                allowed = true;
+                return false; //break
+              }
             });
-        };
+            if(!allowed) {
+              callback(container, null);
+              return;
+            }
+          }
+          provider.params = getNormalizedParams(options[provider.name]) || {};
+          provider.maxWidth = options.maxWidth;
+          provider.maxHeight = options.maxHeight;
+          provider.embedCode(container, resourceURL, callback);
+          return;
+        }
+      }
+
+      callback(container, null);
+    });
+  };
+
+  // Plugin defaults
+  $.fn.oembed.defaults = {
+    maxWidth: null,
+    maxHeight: null,
+    allowed_providers: [],
+    embedMethod: "replace" // "auto", "append", "fill"
+  };
+
+  $.fn.oembed.insertCode = function(container, embedMethod, oembed) {
+    if (oembed === null)
+      return;
+    switch(embedMethod)
+    {
+      case "auto":
+        if (container.attr("href") !== null) {
+          $.fn.oembed.insertCode(container, "append", oembed);
+        }
+        else {
+          $.fn.oembed.insertCode(container, "replace", oembed);
+        }
+        break;
+      case "replace":
+        container.replaceWith(oembed.code);
+        break;
+      case "fill":
+        container.html(oembed.code);
+        break;
+      case "append":
+        var oembedContainer = container.next();
+        if (oembedContainer === null || !oembedContainer.hasClass("oembed-container")) {
+          oembedContainer = container.after('<div class="oembed-container"></div>').next(".oembed-container");
+          if (oembed !== null && oembed.provider_name !== null)
+            oembedContainer.toggleClass("oembed-container-" + oembed.provider_name);
+        }
+        oembedContainer.html(oembed.code);
+        break;
+      default:
+      break;
     }
+  };
+
+  $.fn.oembed.getPhotoCode = function(url, data) {
+    var alt = data.title ? data.title : '';
+    alt += data.author_name ? ' - ' + data.author_name : '';
+    alt += data.provider_name ? ' - ' +data.provider_name : '';
+    var code = '<div><a href="' + url + '" target="_blank"><img src="' + data.url + '" alt="' + alt + '"/></a></div>';
+    if (data.html)
+      code += "<div>" + data.html + "</div>";
+    return code;
+  };
+
+  $.fn.oembed.getVideoCode = function(url, data) {
+    var code = data.html;
+    return code;
+  };
+
+  $.fn.oembed.getRichCode = function(url, data) {
+    var code = data.html;
+    return code;
+  };
+
+  $.fn.oembed.getGenericCode = function(url, data) {
+    var title = (data.title !== null) ? data.title : url,
+        code = '<a href="' + url + '">' + title + '</a>';
+    if (data.html)
+      code += "<div>" + data.html + "</div>";
+    return code;
+  };
+
+  $.fn.oembed.isAvailable = function(url) {
+    var provider = getOEmbedProvider(url);
+    return (provider !== null);
+  };
+
+  /* Private Methods */
+  function getOEmbedProvider(url) {
+    for (var i = 0; i < providers.length; i++) {
+      if (providers[i].matches(url))
+        return providers[i];
+    }
+    return null;
+  }
+
+  function getNormalizedParams(params) {
+    if (params === null)
+      return null;
+    var normalizedParams = {};
+    for (var key in params) {
+      if (key !== null)
+        normalizedParams[key.toLowerCase()] = params[key];
+    }
+    return normalizedParams;
+  }
+
+  var providers = [
+    new OEmbedProvider("fivemin", "5min.com"),
+    new OEmbedProvider("amazon", "amazon.com"),
+    new OEmbedProvider("flickr", "flickr", "http://flickr.com/services/oembed", "jsoncallback"),
+    new OEmbedProvider("googlevideo", "video.google."),
+    new OEmbedProvider("hulu", "hulu.com"),
+    new OEmbedProvider("imdb", "imdb.com"),
+    new OEmbedProvider("metacafe", "metacafe.com"),
+    new OEmbedProvider("qik", "qik.com"),
+    new OEmbedProvider("revision3", "revision3.com"),
+    new OEmbedProvider("slideshare", "slideshare.net"),
+    new OEmbedProvider("twitpic", "twitpic.com"),
+    new OEmbedProvider("viddler", "viddler.com"),
+    new OEmbedProvider("vimeo", "vimeo.com", "http://vimeo.com/api/oembed.json"),
+    new OEmbedProvider("wikipedia", "wikipedia.org"),
+    new OEmbedProvider("wordpress", "wordpress.com"),
+    new OEmbedProvider("youtube", "youtube.com"),
+    new OEmbedProvider("vids.myspace.com", "vids.myspace.com", "http://vids.myspace.com/index.cfm?fuseaction=oembed"),
+    new OEmbedProvider("screenr", "screenr.com", "http://screenr.com/api/oembed.json")
+  ];
+
+  function OEmbedProvider(name, urlPattern, oEmbedUrl, callbackparameter) {
+    this.name = name;
+    this.urlPattern = urlPattern;
+    this.oEmbedUrl = oEmbedUrl ? oEmbedUrl : "http://oohembed.com/oohembed/";
+    this.callbackparameter = callbackparameter ? callbackparameter : "callback";
+    this.maxWidth = 500;
+    this.maxHeight = 400;
+
+    this.matches = function(externalUrl) {
+      // TODO: Convert to Regex
+      return externalUrl.indexOf(this.urlPattern) >= 0;
+    };
+
+    this.getRequestUrl = function(externalUrl) {
+
+      var url = this.oEmbedUrl;
+
+      if (url.indexOf("?") <= 0)
+        url = url + "?";
+      else
+        url = url + "&";
+
+      var qs = "";
+
+      if (this.maxWidth !== null && this.params["maxwidth"] === null)
+        this.params["maxwidth"] = this.maxWidth;
+
+      if (this.maxHeight !== null && this.params["maxheight"] === null)
+        this.params["maxheight"] = this.maxHeight;
+
+      for (var i in this.params) {
+        // We don't want them to jack everything up by changing the callback parameter
+        if (i == this.callbackparameter)
+          continue;
+
+        // allows the options to be set to null, don't send null values to the server as parameters
+        if (this.params[i] !== null)
+          qs += "&" + escape(i) + "=" + this.params[i];
+      }
+
+      url += "format=json&url=" + escape(externalUrl) +
+        qs +
+        "&" + this.callbackparameter + "=?";
+
+      return url;
+    };
+
+    this.embedCode = function(container, externalUrl, callback) {
+      var request = this.getRequestUrl(externalUrl);
+
+      $.getJSON(request, function(data) {
+
+        var oembed = $.extend({}, data);
+
+        var code, type = data.type;
+
+        switch (type) {
+          case "photo":
+            oembed.code = $.fn.oembed.getPhotoCode(externalUrl, data);
+            break;
+          case "video":
+            oembed.code = $.fn.oembed.getVideoCode(externalUrl, data);
+            break;
+          case "rich":
+            oembed.code = $.fn.oembed.getRichCode(externalUrl, data);
+            break;
+          default:
+            oembed.code = $.fn.oembed.getGenericCode(externalUrl, data);
+            break;
+        }
+
+        callback(container, oembed);
+      });
+    };
+  }
 })(jQuery);

--- a/jquery.oembed.js
+++ b/jquery.oembed.js
@@ -212,28 +212,34 @@
     this.embedCode = function(container, externalUrl, callback) {
       var request = this.getRequestUrl(externalUrl);
 
-      $.getJSON(request, function(data) {
+      $.ajax({
+        url: request,
+        dataType: 'json',
+        success: function(data) {
+          var oembed = $.extend({}, data);
 
-        var oembed = $.extend({}, data);
+          var code, type = data.type;
 
-        var code, type = data.type;
+          switch (type) {
+            case "photo":
+              oembed.code = $.fn.oembed.getPhotoCode(externalUrl, data);
+              break;
+            case "video":
+              oembed.code = $.fn.oembed.getVideoCode(externalUrl, data);
+              break;
+            case "rich":
+              oembed.code = $.fn.oembed.getRichCode(externalUrl, data);
+              break;
+            default:
+              oembed.code = $.fn.oembed.getGenericCode(externalUrl, data);
+              break;
+          }
 
-        switch (type) {
-          case "photo":
-            oembed.code = $.fn.oembed.getPhotoCode(externalUrl, data);
-            break;
-          case "video":
-            oembed.code = $.fn.oembed.getVideoCode(externalUrl, data);
-            break;
-          case "rich":
-            oembed.code = $.fn.oembed.getRichCode(externalUrl, data);
-            break;
-          default:
-            oembed.code = $.fn.oembed.getGenericCode(externalUrl, data);
-            break;
+          callback(container, oembed);
+        },
+        error: function() {
+          callback(container, null);
         }
-
-        callback(container, oembed);
       });
     };
   }

--- a/jquery.oembed.js
+++ b/jquery.oembed.js
@@ -2,33 +2,171 @@
  * Likely created by Richard Chamorro under the MIT license.
  * Tweaked up by Samuel Cole.
  */
-(function($) {
-  $.fn.oembed = function(url, options, callback) {
+(function ($) {
+  function OEmbedProvider(name, urlPattern, oEmbedUrl, callbackparameter, format) {
+    this.name = name;
+    this.urlPattern = urlPattern;
+    this.oEmbedUrl = oEmbedUrl ? oEmbedUrl : "http://oohembed.com/oohembed/";
+    this.callbackparameter = callbackparameter ? callbackparameter : "callback";
+    this.format = format ? format : 'json';
+    this.maxWidth = 500;
+    this.maxHeight = 400;
+
+    this.matches = function (externalUrl) {
+      // TODO: Convert to Regex
+      return externalUrl.indexOf(this.urlPattern) >= 0;
+    };
+
+    this.getRequestUrl = function (externalUrl) {
+      var url = this.oEmbedUrl, qs, i;
+
+      if (url.indexOf("?") <= 0) {
+        url = url + "?";
+      } else {
+        url = url + "&";
+      }
+
+      qs = "";
+
+      if (this.maxWidth && !this.params.maxwidth) {
+        this.params.maxwidth = this.maxWidth;
+      }
+
+      if (this.maxHeight && !this.params.maxheight) {
+        this.params.maxheight = this.maxHeight;
+      }
+
+      for (i in this.params) {
+        /*jslint continue: true */
+        // We don't want them to jack everything up by changing the callback parameter
+        if (i === this.callbackparameter) {
+          continue;
+        }
+
+        // allows the options to be set to null, don't send null values to the server as parameters
+        if (this.params[i]) {
+          qs += "&" + encodeURIComponent(i) + "=" + this.params[i];
+        }
+      }
+
+      url += "format=" + this.format + "&url=" + encodeURIComponent(externalUrl) +
+        qs +
+        "&" + this.callbackparameter + "=?";
+
+      return url;
+    };
+
+    this.embedCode = function (container, externalUrl, callback) {
+      var request = this.getRequestUrl(externalUrl);
+
+      $.ajax({
+        url: request,
+        dataType: 'json',
+        success: function (data) {
+          var oembed = $.extend({}, data), 
+            code,
+            type = data.type;
+
+          switch (type) {
+
+          case "photo":
+            oembed.code = $.fn.oembed.getPhotoCode(externalUrl, data);
+            break;
+          case "video":
+            oembed.code = $.fn.oembed.getVideoCode(externalUrl, data);
+            break;
+          case "rich":
+            oembed.code = $.fn.oembed.getRichCode(externalUrl, data);
+            break;
+          default:
+            oembed.code = $.fn.oembed.getGenericCode(externalUrl, data);
+            break;
+
+          }
+
+          callback(container, oembed);
+        },
+        error: function () {
+          callback(container, null);
+        }
+      });
+    };
+  }
+  var providers = [
+    new OEmbedProvider("fivemin", "5min.com"),
+    new OEmbedProvider("amazon", "amazon.com"),
+    new OEmbedProvider("flickr", "flickr", "http://flickr.com/services/oembed", "jsoncallback"),
+    new OEmbedProvider("googlevideo", "video.google."),
+    new OEmbedProvider("hulu", "hulu.com"),
+    new OEmbedProvider("imdb", "imdb.com"),
+    new OEmbedProvider("metacafe", "metacafe.com"),
+    new OEmbedProvider("qik", "qik.com"),
+    new OEmbedProvider("revision3", "revision3.com"),
+    new OEmbedProvider("slideshare", "slideshare.net"),
+    new OEmbedProvider("twitpic", "twitpic.com"),
+    new OEmbedProvider("viddler", "viddler.com"),
+    new OEmbedProvider("vimeo", "vimeo.com", "http://vimeo.com/api/oembed.json"),
+    new OEmbedProvider("wikipedia", "wikipedia.org"),
+    new OEmbedProvider("wordpress", "wordpress.com"),
+    new OEmbedProvider("youtube", "youtube.com"),
+    new OEmbedProvider("vids.myspace.com", "vids.myspace.com", "http://vids.myspace.com/index.cfm?fuseaction=oembed"),
+    new OEmbedProvider("screenr", "screenr.com", "http://screenr.com/api/oembed.json"),
+    new OEmbedProvider("soundcloud", "soundcloud.com", "http://soundcloud.com/oembed", false, 'js')
+  ];
+
+  /* Private Methods */
+  function getOEmbedProvider(url) {
+    var i;
+    for (i = 0; i < providers.length; i += 1) {
+      if (providers[i].matches(url)) {
+        return providers[i];
+      }
+    }
+    return null;
+  }
+
+  function getNormalizedParams(params) {
+    if (params === null) {
+      return null;
+    }
+    var normalizedParams = {}, key;
+    for (key in params) {
+      if (key !== null) {
+        normalizedParams[key.toLowerCase()] = params[key];
+      }
+    }
+    return normalizedParams;
+  }
+
+  $.fn.oembed = function (url, options, callback) {
     options = $.extend(true, $.fn.oembed.defaults, options);
 
-    return this.each(function() {
+    return this.each(function () {
 
       var container = $(this),
-           resourceURL = (url !== null) ? url : container.attr("href"),
-           provider;
+        resourceURL = (url !== null) ? url : container.attr("href"),
+        provider,
+        allowed;
 
-      if (!callback) callback = function(container, oembed) {
-        $.fn.oembed.insertCode(container, options.embedMethod, oembed);
-      };
+      if (!callback) {
+        callback = function (container, oembed) {
+          $.fn.oembed.insertCode(container, options.embedMethod, oembed);
+        };
+      }
 
       if (resourceURL !== null) {
         provider = getOEmbedProvider(resourceURL);
 
         if (provider !== null) {
-          if(options.allowed_providers.length) {
-            var allowed = false;
-            $.each(options.allowed_providers, function() {
-              if(provider.name == this) {
+          if (options.allowed_providers.length) {
+            allowed = false;
+            $.each(options.allowed_providers, function () {
+              if (provider.name === this) {
                 allowed = true;
                 return false; //break
               }
             });
-            if(!allowed) {
+            if (!allowed) {
               callback(container, null);
               return;
             }
@@ -53,194 +191,78 @@
     embedMethod: "replace" // "auto", "append", "fill"
   };
 
-  $.fn.oembed.insertCode = function(container, embedMethod, oembed) {
-    if (oembed === null)
+  $.fn.oembed.insertCode = function (container, embedMethod, oembed) {
+    if (oembed === null) {
       return;
-    switch(embedMethod)
-    {
-      case "auto":
-        if (container.attr("href") !== null) {
-          $.fn.oembed.insertCode(container, "append", oembed);
-        }
-        else {
-          $.fn.oembed.insertCode(container, "replace", oembed);
-        }
-        break;
-      case "replace":
-        container.replaceWith(oembed.code);
-        break;
-      case "fill":
-        container.html(oembed.code);
-        break;
-      case "append":
-        var oembedContainer = container.next();
-        if (oembedContainer === null || !oembedContainer.hasClass("oembed-container")) {
-          oembedContainer = container.after('<div class="oembed-container"></div>').next(".oembed-container");
-          if (oembed !== null && oembed.provider_name !== null)
-            oembedContainer.toggleClass("oembed-container-" + oembed.provider_name);
-        }
-        oembedContainer.html(oembed.code);
-        break;
-      default:
+    }
+    switch (embedMethod) {
+
+    case "auto":
+      if (container.attr("href") !== null) {
+        $.fn.oembed.insertCode(container, "append", oembed);
+      } else {
+        $.fn.oembed.insertCode(container, "replace", oembed);
+      }
       break;
+    case "replace":
+      container.replaceWith(oembed.code);
+      break;
+    case "fill":
+      container.html(oembed.code);
+      break;
+    case "append":
+      var oembedContainer = container.next();
+      if (oembedContainer === null || !oembedContainer.hasClass("oembed-container")) {
+        oembedContainer = container.after('<div class="oembed-container"></div>').next(".oembed-container");
+        if (oembed !== null && oembed.provider_name !== null) {
+          oembedContainer.toggleClass("oembed-container-" + oembed.provider_name);
+        }
+      }
+      oembedContainer.html(oembed.code);
+      break;
+    default:
+      break;
+
     }
   };
 
-  $.fn.oembed.getPhotoCode = function(url, data) {
-    var alt = data.title ? data.title : '';
+  $.fn.oembed.getPhotoCode = function (url, data) {
+    var alt = data.title ? data.title : '',
+      code;
     alt += data.author_name ? ' - ' + data.author_name : '';
-    alt += data.provider_name ? ' - ' +data.provider_name : '';
-    var code = '<div><a href="' + url + '" target="_blank"><img src="' + data.url + '" alt="' + alt + '"/></a></div>';
-    if (data.html)
+    alt += data.provider_name ? ' - ' + data.provider_name : '';
+    code = '<div><a href="' + url + '" target="_blank"><img src="' + data.url + '" alt="' + alt + '"/></a></div>';
+    if (data.html) {
       code += "<div>" + data.html + "</div>";
+    }
     return code;
   };
 
-  $.fn.oembed.getVideoCode = function(url, data) {
+  $.fn.oembed.getVideoCode = function (url, data) {
     var code = data.html;
     return code;
   };
 
-  $.fn.oembed.getRichCode = function(url, data) {
+  $.fn.oembed.getRichCode = function (url, data) {
     var code = data.html;
     return code;
   };
 
-  $.fn.oembed.getGenericCode = function(url, data) {
+  $.fn.oembed.getGenericCode = function (url, data) {
     var title = (data.title !== null) ? data.title : url,
-        code = '<a href="' + url + '">' + title + '</a>';
-    if (data.html)
+      code = '<a href="' + url + '">' + title + '</a>';
+    if (data.html) {
       code += "<div>" + data.html + "</div>";
+    }
     return code;
   };
 
-  $.fn.oembed.isAvailable = function(url) {
+  $.fn.oembed.isAvailable = function (url) {
     var provider = getOEmbedProvider(url);
     return (provider !== null);
   };
 
-  /* Private Methods */
-  function getOEmbedProvider(url) {
-    for (var i = 0; i < providers.length; i++) {
-      if (providers[i].matches(url))
-        return providers[i];
-    }
-    return null;
-  }
 
-  function getNormalizedParams(params) {
-    if (params === null)
-      return null;
-    var normalizedParams = {};
-    for (var key in params) {
-      if (key !== null)
-        normalizedParams[key.toLowerCase()] = params[key];
-    }
-    return normalizedParams;
-  }
 
-  var providers = [
-    new OEmbedProvider("fivemin", "5min.com"),
-    new OEmbedProvider("amazon", "amazon.com"),
-    new OEmbedProvider("flickr", "flickr", "http://flickr.com/services/oembed", "jsoncallback"),
-    new OEmbedProvider("googlevideo", "video.google."),
-    new OEmbedProvider("hulu", "hulu.com"),
-    new OEmbedProvider("imdb", "imdb.com"),
-    new OEmbedProvider("metacafe", "metacafe.com"),
-    new OEmbedProvider("qik", "qik.com"),
-    new OEmbedProvider("revision3", "revision3.com"),
-    new OEmbedProvider("slideshare", "slideshare.net"),
-    new OEmbedProvider("twitpic", "twitpic.com"),
-    new OEmbedProvider("viddler", "viddler.com"),
-    new OEmbedProvider("vimeo", "vimeo.com", "http://vimeo.com/api/oembed.json"),
-    new OEmbedProvider("wikipedia", "wikipedia.org"),
-    new OEmbedProvider("wordpress", "wordpress.com"),
-    new OEmbedProvider("youtube", "youtube.com"),
-    new OEmbedProvider("vids.myspace.com", "vids.myspace.com", "http://vids.myspace.com/index.cfm?fuseaction=oembed"),
-    new OEmbedProvider("screenr", "screenr.com", "http://screenr.com/api/oembed.json"),
-    new OEmbedProvider("soundcloud", "soundcloud.com", "http://soundcloud.com/oembed", false, 'js')
-  ];
 
-  function OEmbedProvider(name, urlPattern, oEmbedUrl, callbackparameter, format) {
-    this.name = name;
-    this.urlPattern = urlPattern;
-    this.oEmbedUrl = oEmbedUrl ? oEmbedUrl : "http://oohembed.com/oohembed/";
-    this.callbackparameter = callbackparameter ? callbackparameter : "callback";
-    this.format = format ? format : 'json';
-    this.maxWidth = 500;
-    this.maxHeight = 400;
-
-    this.matches = function(externalUrl) {
-      // TODO: Convert to Regex
-      return externalUrl.indexOf(this.urlPattern) >= 0;
-    };
-
-    this.getRequestUrl = function(externalUrl) {
-
-      var url = this.oEmbedUrl;
-
-      if (url.indexOf("?") <= 0)
-        url = url + "?";
-      else
-        url = url + "&";
-
-      var qs = "";
-
-      if (this.maxWidth !== null && this.params["maxwidth"] === null)
-        this.params["maxwidth"] = this.maxWidth;
-
-      if (this.maxHeight !== null && this.params["maxheight"] === null)
-        this.params["maxheight"] = this.maxHeight;
-
-      for (var i in this.params) {
-        // We don't want them to jack everything up by changing the callback parameter
-        if (i == this.callbackparameter)
-          continue;
-
-        // allows the options to be set to null, don't send null values to the server as parameters
-        if (this.params[i] !== null)
-          qs += "&" + escape(i) + "=" + this.params[i];
-      }
-
-      url += "format=" + this.format + "&url=" + escape(externalUrl) +
-        qs +
-        "&" + this.callbackparameter + "=?";
-
-      return url;
-    };
-
-    this.embedCode = function(container, externalUrl, callback) {
-      var request = this.getRequestUrl(externalUrl);
-
-      $.ajax({
-        url: request,
-        dataType: 'json',
-        success: function(data) {
-          var oembed = $.extend({}, data);
-
-          var code, type = data.type;
-
-          switch (type) {
-            case "photo":
-              oembed.code = $.fn.oembed.getPhotoCode(externalUrl, data);
-              break;
-            case "video":
-              oembed.code = $.fn.oembed.getVideoCode(externalUrl, data);
-              break;
-            case "rich":
-              oembed.code = $.fn.oembed.getRichCode(externalUrl, data);
-              break;
-            default:
-              oembed.code = $.fn.oembed.getGenericCode(externalUrl, data);
-              break;
-          }
-
-          callback(container, oembed);
-        },
-        error: function() {
-          callback(container, null);
-        }
-      });
-    };
-  }
-})(jQuery);
+}(jQuery));

--- a/jquery.oembed.js
+++ b/jquery.oembed.js
@@ -160,11 +160,12 @@
     new OEmbedProvider("screenr", "screenr.com", "http://screenr.com/api/oembed.json")
   ];
 
-  function OEmbedProvider(name, urlPattern, oEmbedUrl, callbackparameter) {
+  function OEmbedProvider(name, urlPattern, oEmbedUrl, callbackparameter, format) {
     this.name = name;
     this.urlPattern = urlPattern;
     this.oEmbedUrl = oEmbedUrl ? oEmbedUrl : "http://oohembed.com/oohembed/";
     this.callbackparameter = callbackparameter ? callbackparameter : "callback";
+    this.format = format ? format : 'json';
     this.maxWidth = 500;
     this.maxHeight = 400;
 
@@ -200,7 +201,7 @@
           qs += "&" + escape(i) + "=" + this.params[i];
       }
 
-      url += "format=json&url=" + escape(externalUrl) +
+      url += "format=" + this.format + "&url=" + escape(externalUrl) +
         qs +
         "&" + this.callbackparameter + "=?";
 


### PR DESCRIPTION
These are the same changes I emailed you about. Thought you might be interested as a stopgap to unstable.

jQuery oEmbed: clean up spacing, fix for new jquery versions, and add an allowed_providers option.

unstable looks great, btw!
